### PR TITLE
[LINKER-113] tag 별 뉴스 리스트 pagination

### DIFF
--- a/core-api/src/main/java/com/imlinker/coreapi/core/news/NewsController.java
+++ b/core-api/src/main/java/com/imlinker/coreapi/core/news/NewsController.java
@@ -20,36 +20,17 @@ public class NewsController {
 
     private final NewsService newsService;
 
-    @GetMapping
-    @Operation(summary = "태그에 맞는 뉴스 가져오기 (mock)")
-    public ApiResponse<List<GetNewsResponse.Entry>> getNews(@RequestParam List<String> tag) {
-        List<GetNewsResponse.Entry> entries =
-                List.of(
-                        new GetNewsResponse.Entry(
-                                new com.imlinker.domain.tag.model.Tag(1L, "스포츠"),
-                                List.of(
-                                        new GetNewsResponse.SimpleNews(
-                                                1L,
-                                                "스포츠",
-                                                "연합뉴스",
-                                                "https://r.yna.co.kr/global/home",
-                                                "https://r.yna.co.kr/global/home/v01/img/yonhapnews_logo_600x600_kr01.jpg\"")),
-                                1L));
-
-        return ApiResponse.success(entries);
-    }
-
     @GetMapping("/profile")
-    @Operation(summary = "지인 프로필 - 태그에 맞는 뉴스 가져오기 (pagination)")
+    @Operation(summary = "태그에 맞는 뉴스 가져오기 - 지인 프로필/트렌드 핫이슈 (pagination)")
     public ApiResponse<GetNewsResponse.Entry> getProfileNews(
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam Long tagId,
+            @RequestParam List<Long> tagIds,
             @RequestParam(required = false) Long cursorId) {
-        GetNewsParam getNewsParam = newsService.findAllByTagIdWithCursor(size, tagId, cursorId);
+        GetNewsParam getNewsParam = newsService.findAllByTagIdWithCursor(size, tagIds, cursorId);
 
         GetNewsResponse.Entry entry =
                 new GetNewsResponse.Entry(
-                        getNewsParam.tag(),
+                        getNewsParam.tags(),
                         getNewsParam.news().stream().map(GetNewsResponse.SimpleNews::fromNews).toList(),
                         getNewsParam.nextCursor());
 

--- a/core-api/src/main/java/com/imlinker/coreapi/core/news/NewsController.java
+++ b/core-api/src/main/java/com/imlinker/coreapi/core/news/NewsController.java
@@ -20,8 +20,8 @@ public class NewsController {
 
     private final NewsService newsService;
 
-    @GetMapping("/profile")
-    @Operation(summary = "태그에 맞는 뉴스 가져오기 - 지인 프로필/트렌드 핫이슈 (pagination)")
+    @GetMapping()
+    @Operation(summary = "태그에 맞는 뉴스 가져오기 (pagination)")
     public ApiResponse<GetNewsResponse.Entry> getProfileNews(
             @RequestParam(defaultValue = "20") int size,
             @RequestParam List<Long> tagIds,

--- a/core-api/src/main/java/com/imlinker/coreapi/core/news/NewsController.java
+++ b/core-api/src/main/java/com/imlinker/coreapi/core/news/NewsController.java
@@ -2,6 +2,7 @@ package com.imlinker.coreapi.core.news;
 
 import com.imlinker.coreapi.core.news.response.GetNewsResponse;
 import com.imlinker.coreapi.support.response.ApiResponse;
+import com.imlinker.domain.news.GetNewsParam;
 import com.imlinker.domain.news.NewsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,8 +33,26 @@ public class NewsController {
                                                 "스포츠",
                                                 "연합뉴스",
                                                 "https://r.yna.co.kr/global/home",
-                                                "https://r.yna.co.kr/global/home/v01/img/yonhapnews_logo_600x600_kr01.jpg\""))));
+                                                "https://r.yna.co.kr/global/home/v01/img/yonhapnews_logo_600x600_kr01.jpg\"")),
+                                1L));
 
         return ApiResponse.success(entries);
+    }
+
+    @GetMapping("/profile")
+    @Operation(summary = "지인 프로필 - 태그에 맞는 뉴스 가져오기 (pagination)")
+    public ApiResponse<GetNewsResponse.Entry> getProfileNews(
+            @RequestParam int size,
+            @RequestParam Long tagId,
+            @RequestParam(required = false) Long cursorId) {
+        GetNewsParam getNewsParam = newsService.findAllByTagIdWithCursor(size, tagId, cursorId);
+
+        GetNewsResponse.Entry entry =
+                new GetNewsResponse.Entry(
+                        getNewsParam.tag(),
+                        getNewsParam.news().stream().map(GetNewsResponse.SimpleNews::fromNews).toList(),
+                        getNewsParam.nextCursor());
+
+        return ApiResponse.success(entry);
     }
 }

--- a/core-api/src/main/java/com/imlinker/coreapi/core/news/NewsController.java
+++ b/core-api/src/main/java/com/imlinker/coreapi/core/news/NewsController.java
@@ -42,7 +42,7 @@ public class NewsController {
     @GetMapping("/profile")
     @Operation(summary = "지인 프로필 - 태그에 맞는 뉴스 가져오기 (pagination)")
     public ApiResponse<GetNewsResponse.Entry> getProfileNews(
-            @RequestParam int size,
+            @RequestParam(defaultValue = "20") int size,
             @RequestParam Long tagId,
             @RequestParam(required = false) Long cursorId) {
         GetNewsParam getNewsParam = newsService.findAllByTagIdWithCursor(size, tagId, cursorId);

--- a/core-api/src/main/java/com/imlinker/coreapi/core/news/response/GetNewsResponse.java
+++ b/core-api/src/main/java/com/imlinker/coreapi/core/news/response/GetNewsResponse.java
@@ -1,5 +1,6 @@
 package com.imlinker.coreapi.core.news.response;
 
+import com.imlinker.domain.news.model.News;
 import com.imlinker.domain.tag.model.Tag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -11,7 +12,8 @@ public class GetNewsResponse {
     @Schema(description = "관심사 및 뉴스")
     public record Entry(
             @Schema(description = "관심사") Tag tag,
-            @Schema(description = "뉴스 List") List<SimpleNews> news) {}
+            @Schema(description = "뉴스 List") List<SimpleNews> news,
+            @Schema(description = "next cursor ID") Long nextCursor) {}
 
     @Schema(description = "뉴스")
     public record SimpleNews(
@@ -19,5 +21,15 @@ public class GetNewsResponse {
             @Schema(description = "제목") String title,
             @Schema(description = "뉴스 제공자") String newsProvider,
             @Schema(description = "뉴스 URL") String newsUrl,
-            @Schema(description = "섬네일 이미지 URL") String thumbnailUrl) {}
+            @Schema(description = "섬네일 이미지 URL") String thumbnailUrl) {
+
+        public static SimpleNews fromNews(News news) {
+            return new SimpleNews(
+                    news.getId(),
+                    news.getTitle(),
+                    news.getNewsProvider(),
+                    news.getNewsUrl().getValue(),
+                    news.getThumbnailUrl());
+        }
+    }
 }

--- a/core-api/src/main/java/com/imlinker/coreapi/core/news/response/GetNewsResponse.java
+++ b/core-api/src/main/java/com/imlinker/coreapi/core/news/response/GetNewsResponse.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 public class GetNewsResponse {
     @Schema(description = "관심사 및 뉴스")
     public record Entry(
-            @Schema(description = "관심사") Tag tag,
+            @Schema(description = "관심사") List<Tag> tags,
             @Schema(description = "뉴스 List") List<SimpleNews> news,
             @Schema(description = "next cursor ID") Long nextCursor) {}
 

--- a/domain/src/main/java/com/imlinker/domain/news/GetNewsParam.java
+++ b/domain/src/main/java/com/imlinker/domain/news/GetNewsParam.java
@@ -1,0 +1,7 @@
+package com.imlinker.domain.news;
+
+import com.imlinker.domain.news.model.News;
+import com.imlinker.domain.tag.model.Tag;
+import java.util.List;
+
+public record GetNewsParam(Tag tag, List<News> news, Long nextCursor) {}

--- a/domain/src/main/java/com/imlinker/domain/news/GetNewsParam.java
+++ b/domain/src/main/java/com/imlinker/domain/news/GetNewsParam.java
@@ -4,4 +4,4 @@ import com.imlinker.domain.news.model.News;
 import com.imlinker.domain.tag.model.Tag;
 import java.util.List;
 
-public record GetNewsParam(Tag tag, List<News> news, Long nextCursor) {}
+public record GetNewsParam(List<Tag> tags, List<News> news, Long nextCursor) {}

--- a/domain/src/main/java/com/imlinker/domain/news/NewsReader.java
+++ b/domain/src/main/java/com/imlinker/domain/news/NewsReader.java
@@ -2,6 +2,8 @@ package com.imlinker.domain.news;
 
 import com.imlinker.domain.news.model.News;
 import com.imlinker.domain.news.model.NewsRepository;
+import com.imlinker.domain.news.model.query.NewsPaginationQueryCondition;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,5 +15,11 @@ public class NewsReader {
 
     public Optional<News> findByNewsUrl(String newsUrl) {
         return newsRepository.findByNewsUrl(newsUrl);
+    }
+
+    public List<News> findAllByTagIdWithCursor(int size, Long tagId, Long cursorId) {
+        NewsPaginationQueryCondition condition =
+                new NewsPaginationQueryCondition(size, tagId, cursorId);
+        return newsRepository.findAllByTagIdWithCursor(condition);
     }
 }

--- a/domain/src/main/java/com/imlinker/domain/news/NewsReader.java
+++ b/domain/src/main/java/com/imlinker/domain/news/NewsReader.java
@@ -17,9 +17,9 @@ public class NewsReader {
         return newsRepository.findByNewsUrl(newsUrl);
     }
 
-    public List<News> findAllByTagIdWithCursor(int size, Long tagId, Long cursorId) {
+    public List<News> findAllByTagIdWithCursor(int size, List<Long> tagIds, Long cursorId) {
         NewsPaginationQueryCondition condition =
-                new NewsPaginationQueryCondition(size, tagId, cursorId);
+                new NewsPaginationQueryCondition(size, tagIds, cursorId);
         return newsRepository.findAllByTagIdWithCursor(condition);
     }
 }

--- a/domain/src/main/java/com/imlinker/domain/news/NewsService.java
+++ b/domain/src/main/java/com/imlinker/domain/news/NewsService.java
@@ -2,6 +2,8 @@ package com.imlinker.domain.news;
 
 import com.imlinker.domain.common.model.URL;
 import com.imlinker.domain.news.model.News;
+import com.imlinker.domain.tag.TagReader;
+import com.imlinker.domain.tag.model.Tag;
 import com.imlinker.enums.OperationResult;
 import java.util.List;
 import java.util.Optional;
@@ -16,11 +18,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class NewsService {
     private final NewsUpdater newsUpdater;
     private final NewsReader newsReader;
+    private final TagReader tagReader;
 
     public Boolean checkDuplicateNews(String newsUrl) {
         Optional<News> news = newsReader.findByNewsUrl(newsUrl);
-        if (news.isPresent()) return true;
-        else return false;
+        return news.isPresent();
+    }
+
+    public GetNewsParam findAllByTagIdWithCursor(int size, Long tagId, Long cursorId) {
+        Tag tag = tagReader.findById(tagId);
+        List<News> newsList = newsReader.findAllByTagIdWithCursor(size, tagId, cursorId);
+
+        Long nextCursor = null;
+        int curListSize = newsList.size();
+        if (curListSize < size) {
+            nextCursor = -1L;
+        } else {
+            nextCursor = newsList.get(curListSize - 1).getId();
+        }
+
+        return new GetNewsParam(tag, newsList, nextCursor);
     }
 
     @Transactional

--- a/domain/src/main/java/com/imlinker/domain/news/NewsService.java
+++ b/domain/src/main/java/com/imlinker/domain/news/NewsService.java
@@ -25,9 +25,9 @@ public class NewsService {
         return news.isPresent();
     }
 
-    public GetNewsParam findAllByTagIdWithCursor(int size, Long tagId, Long cursorId) {
-        Tag tag = tagReader.findById(tagId);
-        List<News> newsList = newsReader.findAllByTagIdWithCursor(size, tagId, cursorId);
+    public GetNewsParam findAllByTagIdWithCursor(int size, List<Long> tagIds, Long cursorId) {
+        List<Tag> tagList = tagReader.findAllByIdIn(tagIds);
+        List<News> newsList = newsReader.findAllByTagIdWithCursor(size, tagIds, cursorId);
 
         Long nextCursor = null;
         int curListSize = newsList.size();
@@ -37,7 +37,7 @@ public class NewsService {
             nextCursor = newsList.get(curListSize - 1).getId();
         }
 
-        return new GetNewsParam(tag, newsList, nextCursor);
+        return new GetNewsParam(tagList, newsList, nextCursor);
     }
 
     @Transactional

--- a/domain/src/main/java/com/imlinker/domain/news/model/NewsRepository.java
+++ b/domain/src/main/java/com/imlinker/domain/news/model/NewsRepository.java
@@ -1,5 +1,6 @@
 package com.imlinker.domain.news.model;
 
+import com.imlinker.domain.news.model.query.NewsPaginationQueryCondition;
 import java.util.List;
 import java.util.Optional;
 
@@ -7,6 +8,8 @@ public interface NewsRepository {
     News findById(Long id);
 
     News findByTagId(Long tagId);
+
+    List<News> findAllByTagIdWithCursor(NewsPaginationQueryCondition condition);
 
     Optional<News> findByNewsUrl(String newsUrl);
 

--- a/domain/src/main/java/com/imlinker/domain/news/model/query/NewsPaginationQueryCondition.java
+++ b/domain/src/main/java/com/imlinker/domain/news/model/query/NewsPaginationQueryCondition.java
@@ -1,3 +1,5 @@
 package com.imlinker.domain.news.model.query;
 
-public record NewsPaginationQueryCondition(int size, Long tagId, Long cursorId) {}
+import java.util.List;
+
+public record NewsPaginationQueryCondition(int size, List<Long> tagIds, Long cursorId) {}

--- a/domain/src/main/java/com/imlinker/domain/news/model/query/NewsPaginationQueryCondition.java
+++ b/domain/src/main/java/com/imlinker/domain/news/model/query/NewsPaginationQueryCondition.java
@@ -1,0 +1,3 @@
+package com.imlinker.domain.news.model.query;
+
+public record NewsPaginationQueryCondition(int size, Long tagId, Long cursorId) {}

--- a/domain/src/main/java/com/imlinker/domain/tag/TagReader.java
+++ b/domain/src/main/java/com/imlinker/domain/tag/TagReader.java
@@ -11,6 +11,10 @@ import org.springframework.stereotype.Component;
 public class TagReader {
     private final TagRepository tagRepository;
 
+    public Tag findById(Long id) {
+        return tagRepository.findById(id);
+    }
+
     public List<Tag> findAll() {
         return tagRepository.findAll();
     }

--- a/domain/src/main/java/com/imlinker/domain/tag/TagReader.java
+++ b/domain/src/main/java/com/imlinker/domain/tag/TagReader.java
@@ -15,6 +15,10 @@ public class TagReader {
         return tagRepository.findById(id);
     }
 
+    public List<Tag> findAllByIdIn(List<Long> ids) {
+        return tagRepository.findAllByIdIn(ids);
+    }
+
     public List<Tag> findAll() {
         return tagRepository.findAll();
     }

--- a/domain/src/main/java/com/imlinker/domain/tag/TagService.java
+++ b/domain/src/main/java/com/imlinker/domain/tag/TagService.java
@@ -15,6 +15,10 @@ public class TagService {
     private final TagReader tagReader;
     private final TagUpdater tagUpdater;
 
+    public Tag getTag(Long id) {
+        return tagReader.findById(id);
+    }
+
     public List<Tag> getTags() {
         return tagReader.findAll();
     }

--- a/storage/src/main/java/com/imlinker/storage/news/NewsAdaptor.java
+++ b/storage/src/main/java/com/imlinker/storage/news/NewsAdaptor.java
@@ -2,6 +2,7 @@ package com.imlinker.storage.news;
 
 import com.imlinker.domain.news.model.News;
 import com.imlinker.domain.news.model.NewsRepository;
+import com.imlinker.domain.news.model.query.NewsPaginationQueryCondition;
 import com.imlinker.error.ApplicationException;
 import com.imlinker.error.ErrorType;
 import com.imlinker.storage.news.mapper.NewsMapper;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Repository;
 public class NewsAdaptor implements NewsRepository {
 
     private final NewsJpaRepository newsJpaRepository;
+    private final NewsJdbcQueryRepository newsJdbcQueryRepository;
 
     @Override
     public News findById(Long id) {
@@ -32,6 +34,13 @@ public class NewsAdaptor implements NewsRepository {
                         .findByTagId(tagId)
                         .orElseThrow(() -> new ApplicationException(ErrorType.NEWS_NOT_FOUND));
         return NewsMapper.toModel(newsEntity);
+    }
+
+    @Override
+    public List<News> findAllByTagIdWithCursor(NewsPaginationQueryCondition condition) {
+        return newsJdbcQueryRepository.findAllByTagIdWithCursor(condition).stream()
+                .map(NewsMapper::toModel)
+                .toList();
     }
 
     @Override

--- a/storage/src/main/java/com/imlinker/storage/news/NewsEntity.java
+++ b/storage/src/main/java/com/imlinker/storage/news/NewsEntity.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.jdbc.core.RowMapper;
 
 @Getter
 @Entity
@@ -37,4 +38,16 @@ public class NewsEntity {
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
+
+    public static RowMapper<NewsEntity> getRowMapper() {
+        return ((rs, rowNum) ->
+                new NewsEntity(
+                        rs.getLong("id"),
+                        rs.getLong("ref_tag_id"),
+                        rs.getString("title"),
+                        rs.getString("thumbnail_url"),
+                        rs.getString("news_url"),
+                        rs.getString("news_provider"),
+                        rs.getObject("created_at", LocalDateTime.class)));
+    }
 }

--- a/storage/src/main/java/com/imlinker/storage/news/NewsJdbcQueryRepository.java
+++ b/storage/src/main/java/com/imlinker/storage/news/NewsJdbcQueryRepository.java
@@ -1,0 +1,40 @@
+package com.imlinker.storage.news;
+
+import com.imlinker.domain.news.model.query.NewsPaginationQueryCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NewsJdbcQueryRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public List<NewsEntity> findAllByTagIdWithCursor(NewsPaginationQueryCondition condition){
+        String sql =
+                """
+                        SELECT
+                        *
+                        FROM
+                        news
+                        WHERE
+                        ref_tag_id=:tagId
+                        AND
+                        id < :cursorId
+                        ORDER BY
+                        created_at DESC
+                        LIMIT :limit
+                """;
+
+        MapSqlParameterSource namedParameters = new MapSqlParameterSource()
+                .addValue("tagId", condition.tagId())
+                .addValue("cursorId", condition.cursorId() == null? 9223372036854775807L : condition.cursorId())
+                .addValue("limit", condition.size());
+
+        return jdbcTemplate.query(sql, namedParameters, NewsEntity.getRowMapper());
+
+    }
+}

--- a/storage/src/main/java/com/imlinker/storage/news/NewsJdbcQueryRepository.java
+++ b/storage/src/main/java/com/imlinker/storage/news/NewsJdbcQueryRepository.java
@@ -21,7 +21,7 @@ public class NewsJdbcQueryRepository {
                         FROM
                         news
                         WHERE
-                        ref_tag_id=:tagId
+                        ref_tag_id IN (:tagIds)
                         AND
                         id < :cursorId
                         ORDER BY
@@ -29,8 +29,9 @@ public class NewsJdbcQueryRepository {
                         LIMIT :limit
                 """;
 
+
         MapSqlParameterSource namedParameters = new MapSqlParameterSource()
-                .addValue("tagId", condition.tagId())
+                .addValue("tagIds", condition.tagIds())
                 .addValue("cursorId", condition.cursorId() == null? 9223372036854775807L : condition.cursorId())
                 .addValue("limit", condition.size());
 

--- a/storage/src/test/java/com/imlinker/storage/news/NewsJdbcQueryTest.java
+++ b/storage/src/test/java/com/imlinker/storage/news/NewsJdbcQueryTest.java
@@ -3,6 +3,7 @@ package com.imlinker.storage.news;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.imlinker.domain.news.model.query.NewsPaginationQueryCondition;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,8 @@ public class NewsJdbcQueryTest {
         NewsEntity newsEntity = NewsEntity.builder().id(1L).tagId(1L).build();
         newsJpaRepository.save(newsEntity);
 
-        NewsPaginationQueryCondition condition = new NewsPaginationQueryCondition(20, 1L, null);
+        NewsPaginationQueryCondition condition =
+                new NewsPaginationQueryCondition(20, Collections.singletonList(1L), null);
         List<NewsEntity> newsEntityList = newsJdbcQueryRepository.findAllByTagIdWithCursor(condition);
 
         assertThat(newsEntityList.get(0).getId()).isEqualTo(newsEntity.getId());

--- a/storage/src/test/java/com/imlinker/storage/news/NewsJdbcQueryTest.java
+++ b/storage/src/test/java/com/imlinker/storage/news/NewsJdbcQueryTest.java
@@ -1,0 +1,32 @@
+package com.imlinker.storage.news;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.imlinker.domain.news.model.query.NewsPaginationQueryCondition;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class NewsJdbcQueryTest {
+
+    @Autowired NewsJdbcQueryRepository newsJdbcQueryRepository;
+    @Autowired NewsJpaRepository newsJpaRepository;
+
+    @Test
+    @DisplayName("태그에 맞는 뉴스를 가져온다.")
+    public void findAllByTagIdWithCursor() {
+        NewsEntity newsEntity = NewsEntity.builder().id(1L).tagId(1L).build();
+        newsJpaRepository.save(newsEntity);
+
+        NewsPaginationQueryCondition condition = new NewsPaginationQueryCondition(20, 1L, null);
+        List<NewsEntity> newsEntityList = newsJdbcQueryRepository.findAllByTagIdWithCursor(condition);
+
+        assertThat(newsEntityList.get(0).getId()).isEqualTo(newsEntity.getId());
+        assertThat(newsEntityList.get(0).getTagId()).isEqualTo(newsEntity.getTagId());
+    }
+}


### PR DESCRIPTION
## 📍 작업 배경  [#](#background) <span id="background"></span>
<!-- 관련 이슈 링크 및 작업하게 된 이유/배경 설명 -->
- issue: #68 

## 📝 작업 내용  [#](#work_detail) <span id="work_detail"></span>
<!-- 주요 구현 사항 설명 -->
<!-- 필요 시, 응답값 예시 첨부 -->
<img width="200" alt="스크린샷 2024-02-12 오후 7 08 04" src="https://github.com/YAPP-Github/23rd-LiNKER-BE/assets/62213813/f375a576-01a1-453a-a9d2-28ebb229f25e">
<img width="206" alt="스크린샷 2024-02-12 오후 11 23 57" src="https://github.com/YAPP-Github/23rd-LiNKER-BE/assets/62213813/a1bfc64b-2175-44d2-be61-657e61d490da">

- 지인프로필 > 관심주제, 트렌드 핫이슈 API 구현하였습니다
- jdbc template을 활용하여 커서 기반으로 페이지네이션 구현하였고, 
  `size`, `tagIds`, `cursorId`를 query param으로 받도록 하였습니다.
- tag에 해당하는 뉴스 내림차순으로 조회하도록 하였으며, `cursorId`가 query param으로 입력되지 않았을 때가 최초 요청이 되도록 구현하였습니다.
- response 값에 `nextCursor` 변수로 다음 스크롤 위치 지정해주었고, 다음 스크롤이 존재하지 않을 경우에는 `nextCursor`를 -1로 반환합니다

## 💬 코멘트 [#](#comments) <span id="comments"></span>
<!-- 리뷰어에게 전달하고 싶은 사항, 리뷰 시 확인해야 하는 사항, 궁금한 사항 등-->
